### PR TITLE
ring-accumulator

### DIFF
--- a/src/proofofwork.h
+++ b/src/proofofwork.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include <inttypes.h>
 
-#define J_PREFIX_BITS 20
+#define J_PREFIX_BITS 21
 #define J_BUCKET_SIZE_BITS 6
 #define J_MEMORY_BITS (J_PREFIX_BITS + J_BUCKET_SIZE_BITS)
 // XXX: This is important for security. Prover can pre-compute the prefixes
@@ -62,5 +62,9 @@ void juggler_print_solution(solution_t *solution);
 
 juint_t juggler_hash_prefix(const uint8_t *full_nonce, juint_t preimage);
 void juggler_select_buckets(const uint8_t *full_nonce, juint_t selector, juint_t *prefixes);
+
+void bucket_init(bucket_t *bucket);
+void bucket_update(bucket_t *bucket, juint_t item);
+void bucket_final(bucket_t *bucket, juint_t prefix);
 
 #endif

--- a/stats.rb
+++ b/stats.rb
@@ -1,0 +1,13 @@
+B = 5
+S = 4
+M = B + S
+
+sum = 0.0
+1.upto(2**S) do |m|
+  hit_count = 2**S - m
+  vala = (2**B - 1)**(2**M - hit_count) * 2**B
+  valb = 2**( B*(hit_count) + B*(2**M - hit_count) )
+  puts "#{vala.to_f/valb}"
+end
+puts sum
+


### PR DESCRIPTION
This actually makes the code simpler and faster for the same amounts of memory.

There is a choice to be made before merging this. Should the upper bound on the preimage be just the amount of memory, or should it be twice the amount of memory? Before, it was twice the amount of memory, and it's very likely all buckets will be filled before that value is reached. This PR changes it to be just the amount of memory, which to me means "intuitively most buckets should be mostly filled." Before this gets merged, I want to see a quantitative analysis.

What does it have to be for each bucket to be half-full? 75%? 90%? 99%?

(It's simple draw-balls with-replacement probability, shouldn't be too hard to figure out exactly)
